### PR TITLE
Added slack notification from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,6 @@ before_script:
 
 script:
   - yarn test-travis
+
+notifications:
+  slack: "${SLACK_CREDS}"


### PR DESCRIPTION
Configured `SLACK_CREDS` in Travis CI interface.
Notify will be triggered on all defaults more details at: https://docs.travis-ci.com/user/notifications/#Configuring-Slack-notifications